### PR TITLE
Update react-native-passbase.podspec

### DIFF
--- a/react-native-passbase.podspec
+++ b/react-native-passbase.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.requires_arc     = true
   s.swift_version    = '5.0'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'Passbase', '3.5.0'
 end
 


### PR DESCRIPTION
Xcode 12 can sometimes fail to build without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

I had this issue and it took me a while to fix it. This was my fix and seems to be a necessary change per the comment linked above. Tested this on my own device locally and functionality doesn't change but the problem is fixed.